### PR TITLE
fix: stale add/delete page after creating new contender

### DIFF
--- a/src/components/MovieGrid/index.tsx
+++ b/src/components/MovieGrid/index.tsx
@@ -34,7 +34,8 @@ const MovieGrid = (props: { predictions: iPrediction[]; noLine?: boolean }) => {
           {!noLine && i === slots ? (
             <Divider
               style={{
-                width: '100%',
+                position: 'absolute',
+                width: width - theme.windowMargin * 2,
                 marginTop: 10,
                 marginBottom: 10,
                 borderBottomWidth: 1,
@@ -43,12 +44,18 @@ const MovieGrid = (props: { predictions: iPrediction[]; noLine?: boolean }) => {
             />
           ) : null}
           {p.contenderMovie ? (
-            <PosterFromTmdbId
-              movieTmdbId={p.contenderMovie.tmdbId}
-              personTmdbId={p.contenderPerson?.tmdbId}
-              width={(width - theme.windowMargin * 2 + theme.posterMargin) / 5}
-              ranking={i + 1}
-            />
+            <>
+              {!noLine && slots && i >= slots && i < slots + 5 ? (
+                // we want to give a margin on top if this is the row beneath the divider (since divider is absolute pos)
+                <View style={{ marginTop: 20 }} />
+              ) : null}
+              <PosterFromTmdbId
+                movieTmdbId={p.contenderMovie.tmdbId}
+                personTmdbId={p.contenderPerson?.tmdbId}
+                width={(width - theme.windowMargin * 2 + theme.posterMargin) / 5}
+                ranking={i + 1}
+              />
+            </>
           ) : null}
         </View>
       ))}

--- a/src/components/MovieList/MovieListCommunity.tsx
+++ b/src/components/MovieList/MovieListCommunity.tsx
@@ -48,7 +48,7 @@ const MovieListCommunity = (props: iMovieListProps) => {
                 style={{
                   margin: 10,
                   borderWidth: 0.5,
-                  borderColor: COLORS.secondaryDark,
+                  borderColor: COLORS.secondary,
                 }}
               />
             ) : null}

--- a/src/components/MovieList/MovieListDraggable.tsx
+++ b/src/components/MovieList/MovieListDraggable.tsx
@@ -62,8 +62,7 @@ const MovieListDraggable = (props: iMovieListProps) => {
               <Divider
                 style={{
                   margin: 10,
-                  borderWidth: 0.5,
-                  borderColor: COLORS.secondaryDark,
+                  backgroundColor: isActive ? 'transparent' : COLORS.secondary,
                 }}
               />
             ) : null}

--- a/src/hooks/mutations/createActingContender.tsx
+++ b/src/hooks/mutations/createActingContender.tsx
@@ -1,12 +1,11 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import ApiServices from '../../services/graphql';
-import { QueryKeys } from '../../types';
+import { iPrediction } from '../../types';
 
 const useMutationCreateActingContender = () => {
-  const queryClient = useQueryClient();
-
   const [isComplete, setIsComplete] = useState<boolean>(true);
+  const [response, setResponse] = useState<iPrediction | undefined>(undefined);
 
   const { mutate, isLoading } = useMutation({
     mutationFn: async (params: {
@@ -23,13 +22,13 @@ const useMutationCreateActingContender = () => {
         personTmdbId: params.personTmdbId,
       });
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: [QueryKeys.COMMUNITY_EVENT] });
+    onSuccess: (res) => {
+      setResponse(res.data);
       setIsComplete(true);
     },
   });
 
-  return { mutate, isLoading, isComplete };
+  return { mutate, isLoading, isComplete, response };
 };
 
 export default useMutationCreateActingContender;

--- a/src/hooks/mutations/createContender.tsx
+++ b/src/hooks/mutations/createContender.tsx
@@ -1,12 +1,11 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import ApiServices from '../../services/graphql';
-import { QueryKeys } from '../../types';
+import { iPrediction } from '../../types';
 
 const useMutationCreateContender = () => {
-  const queryClient = useQueryClient();
-
   const [isComplete, setIsComplete] = useState<boolean>(true);
+  const [response, setResponse] = useState<iPrediction | undefined>(undefined);
 
   const { mutate, isLoading } = useMutation({
     mutationFn: async (params: {
@@ -21,13 +20,13 @@ const useMutationCreateContender = () => {
         movieTmdbId: params.movieTmdbId,
       });
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: [QueryKeys.COMMUNITY_EVENT] });
+    onSuccess: (res) => {
+      setResponse(res.data);
       setIsComplete(true);
     },
   });
 
-  return { mutate, isLoading, isComplete };
+  return { mutate, isLoading, isComplete, response };
 };
 
 export default useMutationCreateContender;

--- a/src/hooks/mutations/createSongContender.tsx
+++ b/src/hooks/mutations/createSongContender.tsx
@@ -1,12 +1,11 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import ApiServices from '../../services/graphql';
-import { QueryKeys } from '../../types';
+import { iPrediction } from '../../types';
 
 const useMutationCreateSongContender = () => {
-  const queryClient = useQueryClient();
-
   const [isComplete, setIsComplete] = useState<boolean>(true);
+  const [response, setResponse] = useState<iPrediction | undefined>(undefined);
 
   const { mutate, isLoading } = useMutation({
     mutationFn: async (params: {
@@ -25,13 +24,13 @@ const useMutationCreateSongContender = () => {
         title: params.title,
       });
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: [QueryKeys.COMMUNITY_EVENT] });
+    onSuccess: (res) => {
+      setResponse(res.data);
       setIsComplete(true);
     },
   });
 
-  return { mutate, isLoading, isComplete };
+  return { mutate, isLoading, isComplete, response };
 };
 
 export default useMutationCreateSongContender;

--- a/src/hooks/mutations/updateContenderVisibility.tsx
+++ b/src/hooks/mutations/updateContenderVisibility.tsx
@@ -1,12 +1,9 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { ContenderVisibility } from '../../API';
 import ApiServices from '../../services/graphql';
-import { QueryKeys } from '../../types';
 
 const useMutationUpdateContenderVisibility = (onComplete?: () => void) => {
-  const queryClient = useQueryClient();
-
   const [isComplete, setIsComplete] = useState<boolean>(true);
 
   const { mutate, isLoading } = useMutation({
@@ -22,8 +19,7 @@ const useMutationUpdateContenderVisibility = (onComplete?: () => void) => {
         params.visibility,
       );
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: [QueryKeys.COMMUNITY_EVENT] });
+    onSuccess: () => {
       setIsComplete(true);
       onComplete && onComplete();
     },

--- a/src/hooks/mutations/updatePredictions.tsx
+++ b/src/hooks/mutations/updatePredictions.tsx
@@ -21,9 +21,8 @@ const useMutationUpdatePredictions = (onComplete?: () => void) => {
       );
     },
     onSuccess: async () => {
+      // re-fetch predictions so the UI updates
       await queryClient.invalidateQueries({ queryKey: [QueryKeys.PERSONAL_EVENT] });
-      // NOT doing the below makes it faster but the community predictions will take a little bit to sync
-      // await queryClient.invalidateQueries({ queryKey: [QueryKeys.COMMUNITY_EVENT] });
       setIsComplete(true);
       onComplete && onComplete();
     },

--- a/src/screens/Predictions/Category/CategoryPersonal.tsx
+++ b/src/screens/Predictions/Category/CategoryPersonal.tsx
@@ -185,7 +185,7 @@ const CategoryPersonal = () => {
                     },
                   });
                 }}
-                icon={'plus'}
+                icon={'edit-outline'}
               />
             </View>
           </CategoryHeader>

--- a/src/screens/Predictions/CreateContender/CreateFilm.tsx
+++ b/src/screens/Predictions/CreateContender/CreateFilm.tsx
@@ -28,7 +28,7 @@ const CreateFilm = (props: iCreateContenderProps) => {
   const event = _event as iEvent;
 
   // when adding a contender to the list of overall contenders
-  const { mutate, isComplete } = useMutationCreateContender();
+  const { mutate, isComplete, response } = useMutationCreateContender();
 
   const { data: communityData } = useQueryCommunityEvent({ event, includeHidden: true }); // because we use this to see if contender exists, we want to includes hidden contenders
   const communityPredictions = communityData?.[category.id]?.predictions || [];
@@ -51,15 +51,13 @@ const CreateFilm = (props: iCreateContenderProps) => {
     return communityPredictions.find((p) => p.contenderMovie?.tmdbId === tmdbId);
   };
 
+  // block runs after createContender mutation succeeds
   useEffect(() => {
-    if (isComplete && selectedTmdbId) {
-      const newPrediction = getPredictionFromTmdbId(selectedTmdbId);
-      if (newPrediction) {
-        onSelectPrediction(newPrediction);
-        resetSearch();
-      }
+    if (response) {
+      onSelectPrediction(response);
+      resetSearch();
     }
-  }, [isComplete]);
+  }, [response]);
 
   const handleSearch = (s: string) => {
     if (s === '') {

--- a/src/screens/Predictions/CreateContender/CreatePerformance.tsx
+++ b/src/screens/Predictions/CreateContender/CreatePerformance.tsx
@@ -30,7 +30,7 @@ const CreatePerformance = (props: iCreateContenderProps) => {
   const event = _event as iEvent;
 
   // when adding a contender to the list of overall contenders
-  const { mutate, isComplete } = useMutationCreateActingContender();
+  const { mutate, isComplete, response } = useMutationCreateActingContender();
 
   const { data: communityData } = useQueryCommunityEvent({ event, includeHidden: true }); // because we use this to see if contender exists, we want to includes hidden contenders
   const communityPredictions = communityData?.[category.id]?.predictions || [];
@@ -62,15 +62,13 @@ const CreatePerformance = (props: iCreateContenderProps) => {
     );
   };
 
+  // block runs after createContender mutation succeeds
   useEffect(() => {
-    if (isComplete && selectedPersonTmdbId && selectedMovieTmdbId) {
-      const newPrediction = getPerformancePrediction();
-      if (newPrediction) {
-        onSelectPrediction(newPrediction);
-        resetSearch();
-      }
+    if (response && selectedPersonTmdbId && selectedMovieTmdbId) {
+      onSelectPrediction(response);
+      resetSearch();
     }
-  }, [isComplete]);
+  }, [response]);
 
   const handleSearch = (s: string) => {
     if (s === '') {

--- a/src/screens/Predictions/CreateContender/CreateSong.tsx
+++ b/src/screens/Predictions/CreateContender/CreateSong.tsx
@@ -33,7 +33,7 @@ const CreateSong = (props: iCreateContenderProps) => {
   const event = _event as iEvent;
 
   // when adding a contender to the list of overall contenders
-  const { mutate, isComplete } = useMutationCreateSongContender();
+  const { mutate, isComplete, response } = useMutationCreateSongContender();
 
   const { data: communityData } = useQueryCommunityEvent({ event, includeHidden: true }); // because we use this to see if contender exists, we want to includes hidden contenders
   const communityPredictions = communityData?.[category.id]?.predictions || [];
@@ -67,15 +67,13 @@ const CreateSong = (props: iCreateContenderProps) => {
     });
   };
 
+  // block runs after createContender mutation succeeds
   useEffect(() => {
-    if (isComplete && selectedMovieTmdbId) {
-      const newPrediction = getSongPrediction(selectedMovieTmdbId, songTitle);
-      if (newPrediction) {
-        onSelectPrediction(newPrediction);
-        resetSearch();
-      }
+    if (response) {
+      onSelectPrediction(response);
+      resetSearch();
     }
-  }, [isComplete]);
+  }, [response]);
 
   const handleSearch = (s: string) => {
     if (s === '') {

--- a/src/services/graphql/person.ts
+++ b/src/services/graphql/person.ts
@@ -64,28 +64,28 @@ export const createPerson = async (
 
 /**
  * enforce tmdb being unique
- * check to see if movie is already stored (identified by tmdbId)
+ * check to see if person is already stored (identified by tmdbId)
  */
 export const getOrCreatePerson = async (
   tmdbId: number,
 ): Promise<iApiResponse<GetPersonQuery>> => {
   try {
-    // get movies with tmdbId
+    // get people by tmdbId
     const { data: maybePeople } = await getPeopleByTmdb(tmdbId);
     if (!maybePeople?.listPeople) {
       return { status: 'error' };
     }
     let personId = maybePeople.listPeople.items[0]?.id || undefined;
-    // if no movie exists with tmdbId, create one
+    // if no person exists with tmdbId, create one
     if (!personId) {
-      const { data: newMovie } = await createPerson(tmdbId);
-      const pId = newMovie?.createPerson?.id;
+      const { data: newPerson } = await createPerson(tmdbId);
+      const pId = newPerson?.createPerson?.id;
       if (!pId) {
         return { status: 'error' };
       }
       personId = pId;
     }
-    // finally, with existing or created movieId, get the movie
+    // finally, with existing or created movieId, get the person
     const { data } = await getPerson(personId);
     return { status: 'success', data };
   } catch (err) {

--- a/src/services/tmdb/movie.ts
+++ b/src/services/tmdb/movie.ts
@@ -15,7 +15,6 @@ export const getTmdbMovie = async (
     // attempt to get from cache first
     const cacheResponse = await TmdbMovieCache.get(tmdbId);
     if (cacheResponse) {
-      console.log('serving from cache');
       return { status: 'success', data: cacheResponse };
     }
 

--- a/src/services/tmdb/person.ts
+++ b/src/services/tmdb/person.ts
@@ -14,7 +14,6 @@ export const getTmdbPerson = async (
     // attempt to get from cache first
     const cacheResponse = await TmdbPersonCache.get(tmdbId);
     if (cacheResponse) {
-      console.log('serving from cache');
       return { status: 'success', data: cacheResponse };
     }
 


### PR DESCRIPTION
Main fix:
- add/delete predictions page would be stale if you create+add a new contender (doesn't show the new contender)
- solution: create contender mutation returns an iPrediction, which is added to the selectedPredictions list
- the list of options that the user sees is a combination of all community-added contenders and films you've selected that aren't returned in community request
NITS:
- fix divider width in MovieGrid
- remove console.log when cache retrieves item
- change add-delete icon to pencil